### PR TITLE
Send Authorization header rather than access_token parameter.

### DIFF
--- a/google-api-async.js
+++ b/google-api-async.js
@@ -53,8 +53,12 @@ GoogleApi = {
         callback(error, result && result.data);
       });
     } else if (options.params.access_token) {
-        console.log("options.params.access_token" + options.params.access_token);
-        HTTP.call(method, this._host + '/' + path, options, function(error, result) {
+      console.log("options.params.access_token" + options.params.access_token);
+      options.headers = options.headers || {};
+      options.headers.Authorization = 'Bearer ' + options.params.access_token;
+      delete options.params.access_token;
+
+      HTTP.call(method, this._host + '/' + path, options, function(error, result) {
         callback(error, result && result.data);
       });
         


### PR DESCRIPTION
Although sending access_token works perfectly, sending the Authorization header instead is preferable, as stated here :
https://developers.google.com/identity/protocols/OAuth2WebServer#callinganapi

Also, this is the current way of passing the token in the original package.

@philcruz : Thank you very much for this extension, I've been using it successfully, and your blogpost about OAuth + Meteor was also very valuable to help me understand how to work with OAuth without using Meteor Accounts !
